### PR TITLE
minor: fix mlserver link md syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Discover more examples at [Microsoft Machine Learning Server](https://github.com/Microsoft/ML-Server)
 
-In these examples, we will demonstrate how to develop and deploy end-to-end advanced analytics Python solutions with ]ML Server](https://docs.microsoft.com/en-us/machine-learning-server/what-is-machine-learning-server). **The samples provided here are created in Python.**
+In these examples, we will demonstrate how to develop and deploy end-to-end advanced analytics Python solutions with [ML Server](https://docs.microsoft.com/en-us/machine-learning-server/what-is-machine-learning-server). **The samples provided here are created in Python.**
 Samples in R are available in [the ML Server R Templates repository](https://github.com/Microsoft/SQL-Server-R-Services-Samples).
 
 Although these samples have not been written for SQL Server ML Services, they can be deployed in the same manner as the R Templates that are provided in the repository linked above.


### PR DESCRIPTION
**1. What does this PR do?**
fixes markdown syntax for link.

`[link](url)`

**2. TL;DR:**

Existing - ![image](https://user-images.githubusercontent.com/53068787/89065900-2355e200-d38a-11ea-8ae3-58331153c556.png)

This PR - ![image](https://user-images.githubusercontent.com/53068787/89065978-45e7fb00-d38a-11ea-8922-1d29d304bc13.png)

